### PR TITLE
Set up Next.js 14 App Router TypeScript project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# Testing
+/coverage
+
+# Next.js
+/.next/
+/out/
+
+# Production
+/build
+
+# Misc
+.DS_Store
+*.pem
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Local env files
+.env*.local
+.env
+
+# Vercel
+.vercel
+
+# TypeScript
+*.tsbuildinfo
+next-env.d.ts

--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,0 +1,5 @@
+export const runtime = 'nodejs'
+
+export async function GET() {
+  return Response.json({ ok: true })
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "nova",
+  "version": "0.1.0",
+  "private": true,
+  "engines": {
+    "node": "20.18.0"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
+    "@uploadthing/react": "^6.7.2",
+    "autoprefixer": "^10.4.21",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.441.0",
+    "next": "14.2.13",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss-animate": "^1.0.7",
+    "uploadthing": "^6.13.3",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.13",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.6.2"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "es6"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Set up Next.js 14 with App Router and TypeScript
- Configure required dependencies: @supabase/supabase-js, zod, uploadthing, @uploadthing/react, lucide-react
- Add dev dependencies: @types/node, @types/react  
- Configure npm scripts: typecheck, lint, build, dev
- Pin Node.js to version 20.18.0 in package.json engines
- Add app/api/healthz/route.ts with runtime = 'nodejs'

## Test plan
- [x] npm install passes locally
- [x] npm run build passes locally  
- [x] GET /api/healthz returns 200 with { ok: true }
- [x] TypeScript compilation works (tsc --noEmit)

## Acceptance Criteria Met
- ✅ Build passes with npm install && npm run build
- ✅ Health endpoint returns 200 status
- ✅ All required dependencies added
- ✅ Node.js pinned to 20.18.0
- ✅ npm scripts configured correctly

🤖 Generated with [Claude Code](https://claude.ai/code)